### PR TITLE
chore: add Symfony 8 support

### DIFF
--- a/tests/DoctrineTestCase.php
+++ b/tests/DoctrineTestCase.php
@@ -52,6 +52,7 @@ abstract class DoctrineTestCase extends TestCase
             isDevMode: true,
         );
         $config->setEntityNamespaces(['CursorPagination' => 'Silarhi\CursorPagination\Tests\Entity']);
+        $config->enableNativeLazyObjects(true);
         $entityManager = new EntityManager($connection, $config);
 
         $schemaTool = new SchemaTool($entityManager);


### PR DESCRIPTION
Add Symfony 8 compatibility while keeping BC with Symfony 7.

Changes:
- Constraint kept as `^7.0|^8.0`
- Added `enableNativeLazyObjects(true)` for Doctrine (Symfony 8 removed `ProxyHelper::generateLazyGhost`)

All 11 tests pass ✅