### PR TITLE
Add composer-normalize and composer validate CI check

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,12 @@
+{
+    "additional_checks": [
+        {
+            "name": "Composer validate & normalize",
+            "job": {
+                "php": "@lowest",
+                "dependencies": "latest",
+                "command": "composer validate --strict && composer normalize --dry-run --diff"
+            }
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,8 @@
 {
     "name": "silarhi/cursor-pagination",
     "description": "A doctrine ORM cursor based pagination library for faster batch operations.",
+    "license": "MIT",
+    "type": "library",
     "keywords": [
         "doctrine",
         "orm",
@@ -8,22 +10,27 @@
         "cursor",
         "cursor-pagination"
     ],
-    "type": "library",
+    "authors": [
+        {
+            "name": "SILARHI",
+            "email": "dev@silarhi.fr"
+        }
+    ],
     "require": {
         "php": ">=8.2",
         "doctrine/orm": "^3.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^2.0",
+        "ergebnis/composer-normalize": "^2.52",
         "friendsofphp/php-cs-fixer": "^3.94",
         "phpstan/phpstan": "^2",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5|^12|^13",
+        "phpunit/phpunit": "^11.5 || ^12 || ^13",
         "rector/rector": "^2",
-        "symfony/cache": "^7.0|^8.0",
-        "vimeo/psalm": "^5.26|^6"
+        "symfony/cache": "^7.0 || ^8.0",
+        "vimeo/psalm": "^5.26 || ^6"
     },
-    "license": "MIT",
     "autoload": {
         "psr-4": {
             "Silarhi\\CursorPagination\\": "src/"
@@ -34,10 +41,9 @@
             "Silarhi\\CursorPagination\\Tests\\": "tests/"
         }
     },
-    "authors": [
-        {
-            "name": "SILARHI",
-            "email": "dev@silarhi.fr"
+    "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
         }
-    ]
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ergebnis/composer-normalize` as a dev dependency (with its `allow-plugins` entry)
- Normalize `composer.json` (canonical key order, ` || ` constraint separators)
- Add a CI check via `.laminas-ci.json` `additional_checks`: `composer validate --strict && composer normalize --dry-run --diff` on lowest PHP with latest dependencies

## Test plan

- [x] `composer validate --strict` passes locally
- [x] `composer normalize --dry-run` passes locally
- [x] `.laminas-ci.json` validated against the official laminas-ci JSON schema
- [ ] CI matrix picks up the new "Composer validate & normalize" job