### PR TITLE
chore: add composer normalize lint-staged hook + sort-packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "friendsofphp/php-cs-fixer": "^3.94",
         "phpstan/phpstan": "^2",
         "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5 || ^12 || ^13",
+        "phpunit/phpunit": "^11.5 || ^12.0 || ^13.0",
         "rector/rector": "^2",
         "symfony/cache": "^7.0 || ^8.0",
         "vimeo/psalm": "^5.26 || ^6"
@@ -44,6 +44,7 @@
     "config": {
         "allow-plugins": {
             "ergebnis/composer-normalize": true
-        }
+        },
+        "sort-packages": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "lint-staged": ">=15.2.10"
     },
     "lint-staged": {
-        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php"
+        "*.php": "vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php",
+        "composer.json": "composer normalize"
     },
     "scripts": {
         "prepare": "husky"


### PR DESCRIPTION
Completes the composer.json quality setup (the `ergebnis/composer-normalize` dev dependency and the `.laminas-ci.json` validate/normalize check are already on `main`):

- lint-staged hook running `composer normalize` on `composer.json`
- `config.sort-packages` enabled (separate commit)
