### PR TITLE
chore: enable config.bump-after-update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         "allow-plugins": {
             "ergebnis/composer-normalize": true
         },
+        "bump-after-update": "dev",
         "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,15 +21,15 @@
         "doctrine/orm": "^3.0"
     },
     "require-dev": {
-        "doctrine/data-fixtures": "^2.0",
+        "doctrine/data-fixtures": "^2.2.1",
         "ergebnis/composer-normalize": "^2.52",
-        "friendsofphp/php-cs-fixer": "^3.94",
-        "phpstan/phpstan": "^2",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.5 || ^12.0 || ^13.0",
-        "rector/rector": "^2",
-        "symfony/cache": "^7.0 || ^8.0",
-        "vimeo/psalm": "^5.26 || ^6"
+        "friendsofphp/php-cs-fixer": "^3.95.7",
+        "phpstan/phpstan": "^2.2.2",
+        "phpstan/phpstan-strict-rules": "^2.0.11",
+        "phpunit/phpunit": "^11.5.55 || ^12.0 || ^13.0",
+        "rector/rector": "^2.4.5",
+        "symfony/cache": "^7.4.13 || ^8.0",
+        "vimeo/psalm": "^5.26 || ^6.16.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Set `config.bump-after-update` to `dev` so `composer update` keeps dev dependency constraints current (consistent with the other libraries).